### PR TITLE
Removed redundancy in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -29,7 +29,4 @@ Steps to reproduce the behavior:
 ## Additional context 
 <!-- Is there anything specific else that we should know that could help us find/fix this bug? -->
 
-## Screenshot of cheats enabled  
-<!-- Even if you don't think it could effect what happened, sometimes some cheats may break others. We don't know! We may never know, if you don't show us what cheats are enabled. -->
-
 - [ ] I have included the steps to reproduce to the best I am able to share.


### PR DESCRIPTION
See https://github.com/nullworks/cathook/pull/1615

I'm the major contributor of cathook's issue template. 
At the time, people usually just shared screenshots of their GUI. Bencat has recently decided to add a request for config files.
With this, the request for a screenshot is redundant. I've made a pull request to fix this on their end.

Since you're using cathook's issue template, I've also proposed a similar change here. 

Feel free to deny this pull request if screenshots are more important than the config file.. 👀