### PR TITLE
Remove clutter in Pickup Timer

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/Visuals/Visuals.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/Visuals/Visuals.cpp
@@ -386,7 +386,7 @@ void CVisuals::PickupTimers()
 			continue;
 		}
 
-		auto timerText = tfm::format("%s: %.1fs", pickupData->Type ? "HEALTH" : "AMMO", 10.f - timeDiff);
+		auto timerText = tfm::format("%.1f", pickupData->Type ? "HEALTH" : "AMMO", 10.f - timeDiff);
 		auto color = pickupData->Type ? Colors::Health : Colors::Ammo;
 		
 		Vec3 vScreen;


### PR DESCRIPTION
It's very obvious if it's health/ammo judging based on the color of the text, we don't need `Health:`/`Ammo:` taking up space

It's obvious that it's a second because of how fast it's ticking down, we don't need `s` taking up space

The tempo/rhythm is easy (it's literally one beat every 1 second), you don't need the flashing .9-.0 taking up space

Before:
![image](https://user-images.githubusercontent.com/17802843/161472972-aba12ac4-9a7f-4992-b8c3-f94646cfd15d.png)

After:
![image](https://user-images.githubusercontent.com/17802843/161473041-823b9871-3afc-4635-9712-62634bfda972.png)

If possible, maybe we could increase the size of the text just slightly now that we have so much clutter-free space.

Untested
