### PR TITLE
Fix CanShoot issue with spy

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
+++ b/Fedoraware/TeamFortress2/TeamFortress2/SDK/Main/BaseCombatWeapon/BaseCombatWeapon.h
@@ -73,7 +73,7 @@ public: //Everything else, lol
 	{
 		DYNVAR_RETURN(float, this, "DT_TFWeaponBase", "LocalActiveTFWeaponData", "m_flObservedCritChance");
 	}
-	
+
 	//str8 outta cathook
 	__inline bool AmbassadorCanHeadshot()
 	{
@@ -180,6 +180,9 @@ public: //Everything else, lol
 					if (!flTimer)
 						flTimer = I::GlobalVars->curtime;
 
+					if (flTimer > I::GlobalVars->curtime)
+						flTimer = 0.0f;
+
 					if ((I::GlobalVars->curtime - flTimer) < 0.4f)
 						return false;
 				}
@@ -195,6 +198,9 @@ public: //Everything else, lol
 				else {
 					if (!flTimer)
 						flTimer = I::GlobalVars->curtime;
+
+					if (flTimer > I::GlobalVars->curtime)
+						flTimer = 0.0f;
 
 					if ((I::GlobalVars->curtime - flTimer) < 2.0f)
 						return false;


### PR DESCRIPTION
CanShoot returned false if you had deadringer up or cloaked, or if you were in the middle of pulling deadringer down or uncloaking. It used a timer with curtime, but the timer did not get reset on join new server and it return false until curtime catched up. so now timer get reset if timer is higher than curtime. This also fix issue with autostab not working on new server