### PR TITLE
Increased SpyWarning range

### DIFF
--- a/Fedoraware/TeamFortress2/TeamFortress2/Features/SpyWarning/SpyWarning.cpp
+++ b/Fedoraware/TeamFortress2/TeamFortress2/Features/SpyWarning/SpyWarning.cpp
@@ -113,7 +113,7 @@ void CSpyWarning::Run()
 
 			Vec3 vEnemyPos = pEnemy->GetWorldSpaceCenter();
 
-			if (vLocalPos.DistTo(vEnemyPos) > 400.0f)
+			if (vLocalPos.DistTo(vEnemyPos) > 700.0f)
 			{
 				continue;
 			}


### PR DESCRIPTION
I'm a bad player, apparently I can't react to the spy warning in time.
I'd appreciate it if someone could add a slider to modify this value. But for now, there's a hard-coded small increase that'll hopefully give bad players like me a little bit more time to react to a spy.